### PR TITLE
More flexible SMTP configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,11 @@ DATABASE_NAME=newsletter_prod
 DATABASE_USERNAME=postgres
 DATABASE_PASSWORD=
 
+MAIL_SMTP_HOST=smtp.example.com
 MAIL_USER_NAME=xxxxxxxxxxxxx
 MAIL_PASSWORD=xxxxxxxxxxxxx
 MAIL_FROM=newsletter@example.com
+MAIL_DOMAIN=example.com
 
 MANAGER_EMAIL=manager@example.com
 MANAGER_PASSWORD=change_me_in_production

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,11 @@
 Rails.application.configure do
+
+  MAIL_DEFAULTS = {
+    host: 'smtp.mandrillapp.com',
+    smtp_port: 587,
+    smtp_auth_method: :plain,
+    starttls: true
+  }
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on
@@ -20,13 +27,13 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.smtp_settings = {
-    address: 'smtp.mandrillapp.com',
-    port: 587,
+    address: ENV['MAIL_SMTP_HOST'] || MAIL_DEFAULTS[:host],
+    port: ENV['MAIL_SMTP_PORT'] || MAIL_DEFAULTS[:smtp_port],
     user_name: ENV['MAIL_USER_NAME'],
     password: ENV['MAIL_PASSWORD'],
-    authentication: :plain,
-    enable_starttls_auto: true,
-    domain: ENV['DOMAIN']
+    authentication: (ENV['MAIL_SMTP_AUTH_METHOD'] || MAIL_DEFAULTS[:smtp_auth_method]).to_sym,
+    enable_starttls_auto: !!ENV['MAIL_STARTTLS'] || MAIL_DEFAULTS[:starttls],
+    domain: ENV['MAIL_DOMAIN'] || ENV['DOMAIN']
   }
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,10 +1,9 @@
 Rails.application.configure do
 
   MAIL_DEFAULTS = {
-    host: 'smtp.mandrillapp.com',
-    smtp_port: 587,
-    smtp_auth_method: :plain,
-    starttls: true
+    port: 587,
+    authentication: :plain,
+    enable_starttls_auto: true
   }
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -27,12 +26,12 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.smtp_settings = {
-    address: ENV['MAIL_SMTP_HOST'] || MAIL_DEFAULTS[:host],
-    port: ENV['MAIL_SMTP_PORT'] || MAIL_DEFAULTS[:smtp_port],
+    address: ENV['MAIL_SMTP_HOST'],
+    port: ENV['MAIL_SMTP_PORT'] || MAIL_DEFAULTS[:port],
     user_name: ENV['MAIL_USER_NAME'],
     password: ENV['MAIL_PASSWORD'],
-    authentication: (ENV['MAIL_SMTP_AUTH_METHOD'] || MAIL_DEFAULTS[:smtp_auth_method]).to_sym,
-    enable_starttls_auto: !!ENV['MAIL_STARTTLS'] || MAIL_DEFAULTS[:starttls],
+    authentication: (ENV['MAIL_SMTP_AUTH_METHOD'] || MAIL_DEFAULTS[:authentication]).to_sym,
+    enable_starttls_auto: !!ENV['MAIL_STARTTLS'] || MAIL_DEFAULTS[:enable_starttls_auto],
     domain: ENV['MAIL_DOMAIN'] || ENV['DOMAIN']
   }
   # Print deprecation notices to the Rails logger.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,10 +1,9 @@
 Rails.application.configure do
 
   MAIL_DEFAULTS = {
-    host: 'smtp.mandrillapp.com',
-    smtp_port: 587,
-    smtp_auth_method: :plain,
-    starttls: true
+    port: 587,
+    authentication: :plain,
+    enable_starttls_auto: true
   }
 
   # Settings specified here will take precedence over those in config/application.rb.
@@ -76,12 +75,12 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.smtp_settings = {
-    address: ENV['MAIL_SMTP_HOST'] || MAIL_DEFAULTS[:host],
-    port: ENV['MAIL_SMTP_PORT'] || MAIL_DEFAULTS[:smtp_port],
+    address: ENV['MAIL_SMTP_HOST'],
+    port: ENV['MAIL_SMTP_PORT'] || MAIL_DEFAULTS[:port],
     user_name: ENV['MAIL_USER_NAME'],
     password: ENV['MAIL_PASSWORD'],
-    authentication: (ENV['MAIL_SMTP_AUTH_METHOD'] || MAIL_DEFAULTS[:smtp_auth_method]).to_sym,
-    enable_starttls_auto: !!ENV['MAIL_STARTTLS'] || MAIL_DEFAULTS[:starttls],
+    authentication: (ENV['MAIL_SMTP_AUTH_METHOD'] || MAIL_DEFAULTS[:authentication]).to_sym,
+    enable_starttls_auto: !!ENV['MAIL_STARTTLS'] || MAIL_DEFAULTS[:enable_starttls_auto],
     domain: ENV['MAIL_DOMAIN'] || ENV['DOMAIN']
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,12 @@
 Rails.application.configure do
+
+  MAIL_DEFAULTS = {
+    host: 'smtp.mandrillapp.com',
+    smtp_port: 587,
+    smtp_auth_method: :plain,
+    starttls: true
+  }
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -68,13 +76,13 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.smtp_settings = {
-    address: 'smtp.mandrillapp.com',
-    port: 587,
+    address: ENV['MAIL_SMTP_HOST'] || MAIL_DEFAULTS[:host],
+    port: ENV['MAIL_SMTP_PORT'] || MAIL_DEFAULTS[:smtp_port],
     user_name: ENV['MAIL_USER_NAME'],
     password: ENV['MAIL_PASSWORD'],
-    authentication: :plain,
-    enable_starttls_auto: true,
-    domain: ENV['DOMAIN']
+    authentication: (ENV['MAIL_SMTP_AUTH_METHOD'] || MAIL_DEFAULTS[:smtp_auth_method]).to_sym,
+    enable_starttls_auto: !!ENV['MAIL_STARTTLS'] || MAIL_DEFAULTS[:starttls],
+    domain: ENV['MAIL_DOMAIN'] || ENV['DOMAIN']
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
This allows non-mandrill SMTP servers to be used. Necessary if you want to use
SendGrid, Mailgun, Gmail, etc.
